### PR TITLE
Better handle docker images of node.js

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+LICENSE
+README.md
+Dockerfile
+Dockerfile-LTS-Carbon

--- a/Dockerfile-LTS-Carbon
+++ b/Dockerfile-LTS-Carbon
@@ -1,0 +1,51 @@
+FROM alpine:3.6
+
+ENV VERSION=v8.9.4 NPM_VERSION=5
+
+# For base builds
+# ENV CONFIG_FLAGS="--fully-static --without-npm" DEL_PKGS="libstdc++" RM_DIRS=/usr/include
+
+RUN apk add --no-cache curl make gcc g++ python linux-headers binutils-gold gnupg libstdc++ && \
+  for server in pgp.mit.edu keyserver.pgp.com ha.pool.sks-keyservers.net; do \
+    gpg --keyserver $server --recv-keys \
+      94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+      FD3A5288F042B6850C66B31F09FE44734EB7990E \
+      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+      B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+      56730D5401028683275BD23C23EFEFE93C4CFFFE \
+      77984A986EBC2AA786BC0F66B01FBB92821C587A && break; \
+  done && \
+  curl -sfSLO https://nodejs.org/dist/${VERSION}/node-${VERSION}.tar.xz && \
+  curl -sfSL https://nodejs.org/dist/${VERSION}/SHASUMS256.txt.asc | gpg --batch --decrypt | \
+    grep " node-${VERSION}.tar.xz\$" | sha256sum -c | grep ': OK$' && \
+  tar -xf node-${VERSION}.tar.xz && \
+  cd node-${VERSION} && \
+  ./configure --prefix=/usr ${CONFIG_FLAGS} && \
+  make -j$(getconf _NPROCESSORS_ONLN) && \
+  make install && \
+  cd / && \
+  if [ -z "$CONFIG_FLAGS" ]; then \
+    if [ -n "$NPM_VERSION" ]; then \
+      npm install -g npm@${NPM_VERSION}; \
+    fi; \
+    find /usr/lib/node_modules/npm -name test -o -name .bin -type d | xargs rm -rf; \
+    if [ -n "$YARN_VERSION" ]; then \
+      for server in pgp.mit.edu keyserver.pgp.com ha.pool.sks-keyservers.net; do \
+        gpg --keyserver $server --recv-keys \
+          6A010C5166006599AA17F08146C2130DFD2497F5 && break; \
+      done && \
+      curl -sfSL -O https://yarnpkg.com/${YARN_VERSION}.tar.gz -O https://yarnpkg.com/${YARN_VERSION}.tar.gz.asc && \
+      gpg --batch --verify ${YARN_VERSION}.tar.gz.asc ${YARN_VERSION}.tar.gz && \
+      mkdir /usr/local/share/yarn && \
+      tar -xf ${YARN_VERSION}.tar.gz -C /usr/local/share/yarn --strip 1 && \
+      ln -s /usr/local/share/yarn/bin/yarn /usr/local/bin/ && \
+      ln -s /usr/local/share/yarn/bin/yarnpkg /usr/local/bin/ && \
+      rm ${YARN_VERSION}.tar.gz*; \
+    fi; \
+  fi && \
+  apk del curl make gcc g++ python linux-headers binutils-gold gnupg ${DEL_PKGS} && \
+  rm -rf ${RM_DIRS} /node-${VERSION}* /usr/share/man /tmp/* /var/cache/apk/* \
+    /root/.npm /root/.node-gyp /root/.gnupg /usr/lib/node_modules/npm/man \
+    /usr/lib/node_modules/npm/doc /usr/lib/node_modules/npm/html /usr/lib/node_modules/npm/scripts

--- a/README.md
+++ b/README.md
@@ -2,4 +2,15 @@
 
 Based on the awesome https://github.com/mhart/alpine-node, thanks a bunch @mhart!
 
-Current nodejs version: 6.2.0
+Current nodejs version: 6.2.0 is held at dialonce/nodejs:latest because of the usage in other docker files across dial once projects. Main Dockerfile for that is Dockerfile.
+
+Dockerfile-LTS-Carbon holds the Node version v8.9.4 and npm version  which is, currently, the latest long term supported version of node (LTS)
+
+## Building
+You should build images locally and make sure, by checking the logs, that the images were build correctly without any significant errors.
+`build.sh`file contains examples
+
+## Publishing
+After an image s build it needs to be published with a dialonce/node.js:<version> tag. To publish you need to be logged in locally via docker to your account which is added to dialonce organisation on docker hub. See also comments in `build.sh`file.
+
+

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# This script is reference on how to build Node.js images and publis them
+# The Node.js latest image, based on boron currently (Node 6.2.11)
+docker image build --file=Dockerfile --label="Node.js LATEST -> LTS Boron" --pull --tag="dialonce/nodejs:latest" .
+#docker image push dialonce/nodejs:latest
+
+# The Node.js BORON image, based on  Node 6.2.11
+docker image build --file=Dockerfile --label="Node.js LTS Boron" --pull --tag="dialonce/nodejs:lts-boron" .
+#docker image push dialonce/nodejs:lts-boron
+
+# The Node.js LTS CARBON image, based on  Node 8.9.4
+docker image build --file=Dockerfile-LTS-Carbon --label="Node.js LTS Carbon" --pull --tag="dialonce/nodejs:lts-carbon" .
+#docker image push dialonce/nodejs:lts-carbon


### PR DESCRIPTION
Split per LTS version and add an informative script to build Docker images locally.