### PR TITLE
Update tls-carbon to 8.11.3 and add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,46 @@
+# Created by .ignore support plugin (hsz.mobi)
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:edge
 
-ENV VERSION=v6.2.0 NPM_VERSION=3
+ENV VERSION=v6.14.3 NPM_VERSION=3
 
 # For base builds, no NPM
 # ENV CONFIG_FLAGS="--without-npm" RM_DIRS=/usr/include

--- a/Dockerfile-LTS-Carbon
+++ b/Dockerfile-LTS-Carbon
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.7
 
 ENV VERSION=v8.11.3 NPM_VERSION=5
 

--- a/Dockerfile-LTS-Carbon
+++ b/Dockerfile-LTS-Carbon
@@ -1,6 +1,6 @@
 FROM alpine:3.7
 
-ENV VERSION=v8.11.3 NPM_VERSION=5
+ENV VERSION=v8.11.3 NPM_VERSION=6
 
 # For base builds
 # ENV CONFIG_FLAGS="--fully-static --without-npm" DEL_PKGS="libstdc++" RM_DIRS=/usr/include

--- a/Dockerfile-LTS-Carbon
+++ b/Dockerfile-LTS-Carbon
@@ -1,6 +1,6 @@
 FROM alpine:3.6
 
-ENV VERSION=v8.9.4 NPM_VERSION=5
+ENV VERSION=v8.11.3 NPM_VERSION=5
 
 # For base builds
 # ENV CONFIG_FLAGS="--fully-static --without-npm" DEL_PKGS="libstdc++" RM_DIRS=/usr/include

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# This script is reference on how to build Node.js images and publis them
+# This script is reference on how to build Node.js images and publish them
 # The Node.js latest image, based on boron currently (Node 6.2.11)
 docker image build --file=Dockerfile --label="Node.js LATEST -> LTS Boron" --pull --tag="dialonce/nodejs:latest" .
 #docker image push dialonce/nodejs:latest
@@ -8,6 +8,6 @@ docker image build --file=Dockerfile --label="Node.js LATEST -> LTS Boron" --pul
 docker image build --file=Dockerfile --label="Node.js LTS Boron" --pull --tag="dialonce/nodejs:lts-boron" .
 #docker image push dialonce/nodejs:lts-boron
 
-# The Node.js LTS CARBON image, based on  Node 8.9.4
+# The Node.js LTS CARBON image, based on  Node 8.9.4 or newer
 docker image build --file=Dockerfile-LTS-Carbon --label="Node.js LTS Carbon" --pull --tag="dialonce/nodejs:lts-carbon" .
 #docker image push dialonce/nodejs:lts-carbon


### PR DESCRIPTION
Update to Node.js 8.11.3 as recommended by Node.js security team to fix known vulnerabilities.
Update lts-boron and latest images to node 6.14.3
Add .gitignore

Image built and pushed to docker hub https://hub.docker.com/r/dialonce/nodejs/tags/